### PR TITLE
Add Lato and some Civis coloring to custom.css

### DIFF
--- a/civis_jupyter_notebooks/assets/custom.css
+++ b/civis_jupyter_notebooks/assets/custom.css
@@ -5,3 +5,20 @@
 #notebook-container {
   min-width: 95%;
 }
+
+/* Make the notebook interface text look like the rest of the platform. */
+body {
+  font-family: Lato, "Trebuchet MS", Arial, sans-serif;
+}
+
+/* Don't show a border around input cells for a slightly cleaner look. */
+div.input_area { border: 0px; }
+div.cell { border: 0px; }
+
+/* Make a few other UI elements use Civis colors similar to the defaults
+(e.g., use Civis blue instead of the blue used for selected cells.) */
+a { color: #0194D3; }
+div.input_prompt { color: #006082; }
+div.cell.selected:before, div.cell.selected.jupyter-soft-selected:before {background: #0194D3;}
+.edit_mode div.cell.selected:before { background: #49DEA4; }
+div.output_prompt {color:#D8432C;}


### PR DESCRIPTION
This makes a few minor CSS tweaks to change how notebooks show up.  In particular, this changes the notebook interface font to Lato (code is still monospace), changes a few colors, and removes the box around cells for a slightly cleaner look.

I have some more CSS to make syntax highlighting use Civis colors, but for concerns about consistency with other syntax highlighting in the platform, I didn't include that here.

current:
![screen shot 2017-09-20 at 12 38 36 pm](https://user-images.githubusercontent.com/181744/30658567-bb3e3cce-9e00-11e7-9be4-a1da563c08c9.png)

with this PR:
![screen shot 2017-09-20 at 12 26 58 pm](https://user-images.githubusercontent.com/181744/30658564-b93aa35e-9e00-11e7-8ab2-99988e1536a2.png)
