### PR TITLE
[CIVP-12555] upgrade to ipywidgets 7

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -69,6 +69,17 @@ Contributing
 
 See ``CONTIBUTING.md`` for information about contributing to this project.
 
+
+Miscellany
+----------
+
+The ordering of the packages in ``requirements.txt`` seems to be important
+because of how pip processes them. In particular, ``ipywidgets`` needs to be
+after ``civis-jupyter-extensions`` to work in the
+`civis-jupyter-python2 image
+<https://github.com/civisanalytics/civis-jupyter-python2>`_.
+
+
 License
 -------
 

--- a/civis_jupyter_notebooks/__main__.py
+++ b/civis_jupyter_notebooks/__main__.py
@@ -25,7 +25,8 @@ def cli():
 
     # enable civisjupyter extension
     for cmd in ['jupyter nbextension install --py civis_jupyter_ext',
-                'jupyter nbextension enable --py civis_jupyter_ext']:
+                'jupyter nbextension enable --py civis_jupyter_ext',
+                'jupyter nbextension enable --py widgetsnbextension']:
         subprocess.check_call(cmd, shell=True)
 
     # copy code

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ click~=6.7
 notebook~=5.1
 six~=1.10
 civis-jupyter-extensions~=0.1
+ipywidgets~=7.0


### PR DESCRIPTION
This makes sure ipywidgets is the latest version (7.0.x).  

Currently the docker image produced by [civis-jupyter-python3](https://github.com/civisanalytics/civis-jupyter-python3) has an older version because the notebook package in conda doesn't require ipywidgets 7.0.

Alternatively, we could switch to using conda forge to install dependencies in civis-jupyter-python3 and its upstream images...  The base conda repository seems [only sort of maintained](https://github.com/conda/conda-recipes#deprecation-notice), so packages like jupyter widgets aren't always up-to-date.

This isn't a big priority.