### PR TITLE
[CIVP-13473] Git clone

### DIFF
--- a/civis_jupyter_notebooks/assets/civis-git-clone
+++ b/civis_jupyter_notebooks/assets/civis-git-clone
@@ -1,7 +1,7 @@
-#!/usr/bin/env/python
+#!/usr/bin/env python
 
 import os
-from civis_jupyter_notebooks.git_utils import CivisGit, GitError
+from civis_jupyter_notebooks.git_utils import CivisGit, CivisGitError
 from civis_jupyter_notebooks import log_utils
 
 stream_logger = log_utils.setup_stream_logging()
@@ -11,7 +11,7 @@ if os.environ.get('GIT_REPO_URL'):
         stream_logger.info('cloning git repository')
         CivisGit().clone_repository()
         stream_logger.info('clone complete')
-    except GitError as e:
+    except CivisGitError as e:
         # Initialize logger here so directory is empty for git clone
         file_logger = log_utils.setup_file_logging()
         file_logger.error(str(e))

--- a/civis_jupyter_notebooks/assets/git-clone
+++ b/civis_jupyter_notebooks/assets/git-clone
@@ -4,7 +4,6 @@ import os
 from civis_jupyter_notebooks.git_utils import CivisGit, GitError
 from civis_jupyter_notebooks import log_utils
 
-file_logger = log_utils.setup_file_logging()
 stream_logger = log_utils.setup_stream_logging()
 
 if os.environ.get('GIT_REPO_URL'):
@@ -13,4 +12,6 @@ if os.environ.get('GIT_REPO_URL'):
         CivisGit().clone_repository()
         stream_logger.info('clone complete')
     except GitError as e:
+        # Initialize logger here so directory is empty for git clone
+        file_logger = log_utils.setup_file_logging()
         file_logger.error(str(e))

--- a/civis_jupyter_notebooks/assets/git-clone
+++ b/civis_jupyter_notebooks/assets/git-clone
@@ -1,8 +1,0 @@
-#!/bin/bash
-
-# Attempt a shallow clone to start.  If a commit hash is specified as the repo ref, this will fail and we need to do a full clone instead.
-if ! git clone "$GIT_REPO_URL" --depth=1 --branch "$GIT_REPO_REF" "$GIT_REPO_MOUNT_PATH"; then
-  git clone "$GIT_REPO_URL" "$GIT_REPO_MOUNT_PATH"
-  cd "$GIT_REPO_MOUNT_PATH"
-  git checkout "$GIT_REPO_REF"
-fi

--- a/civis_jupyter_notebooks/assets/git-clone
+++ b/civis_jupyter_notebooks/assets/git-clone
@@ -2,14 +2,15 @@
 
 import os
 from civis_jupyter_notebooks.git_utils import CivisGit, GitError
-from civis_jupyter_notebooks import platform_persistence
+from civis_jupyter_notebooks import log_utils
 
+file_logger = log_utils.setup_file_logging()
+stream_logger = log_utils.setup_stream_logging()
 
 if os.environ.get('GIT_REPO_URL'):
     try:
-        platform_persistence.logger.info('cloning git repository')
+        stream_logger.info('cloning git repository')
         CivisGit().clone_repository()
-        platform_persistence.logger.info('git repository cloned')
+        stream_logger.info('clone complete')
     except GitError as e:
-        platform_persistence.logger.error(str(e))
-        # TODO: Have some sort of check to stop the rest of the code from executing
+        file_logger.error(str(e))

--- a/civis_jupyter_notebooks/assets/git-clone
+++ b/civis_jupyter_notebooks/assets/git-clone
@@ -1,0 +1,15 @@
+#!/usr/bin/env/python
+
+import os
+from civis_jupyter_notebooks.git_utils import CivisGit, GitError
+from civis_jupyter_notebooks import platform_persistence
+
+
+if os.environ.get('GIT_REPO_URL'):
+    try:
+        platform_persistence.logger.info('cloning git repository')
+        CivisGit().clone_repository()
+        platform_persistence.logger.info('git repository cloned')
+    except GitError as e:
+        platform_persistence.logger.error(str(e))
+        # TODO: Have some sort of check to stop the rest of the code from executing

--- a/civis_jupyter_notebooks/assets/initialize-git
+++ b/civis_jupyter_notebooks/assets/initialize-git
@@ -2,6 +2,8 @@
 # TODO: write conditional for setting up SSH Key
 
 if test $GIT_CREDENTIAL; then
+  git config --global core.excludesfile ~/.gitignore_global
+  echo "civis-notebook-logs.log" > ~/.gitignore_global
   # Store GIT_CREDENTIAL in the credential cache to avoid writing token to disk
   # This will only work with Github tokens!
   git config --global credential.helper 'cache --timeout=10000000'

--- a/civis_jupyter_notebooks/assets/jupyter_notebook_config.py
+++ b/civis_jupyter_notebooks/assets/jupyter_notebook_config.py
@@ -27,7 +27,7 @@ c.FileContentsManager.post_save_hook = platform_persistence.post_save
 NOTEBOOK_PATH = os.path.expanduser(os.path.join('~', 'work'))
 nb_file_path = os.environ.get('NOTEBOOK_FILE_PATH')
 if nb_file_path:
-    NOTEBOOK_PATH = os.path.join(NOTEBOOK_PATH, nb_file_path.strip('/'))
+    NOTEBOOK_PATH = os.path.join(NOTEBOOK_PATH, 'repo', nb_file_path.strip('/'))
 else:
     NOTEBOOK_PATH = os.path.join(NOTEBOOK_PATH, 'notebook.ipynb')
 

--- a/civis_jupyter_notebooks/assets/jupyter_notebook_config.py
+++ b/civis_jupyter_notebooks/assets/jupyter_notebook_config.py
@@ -23,8 +23,8 @@ c.NotebookApp.allow_root = True
 c.FileContentsManager.post_save_hook = platform_persistence.post_save
 c.MultiKernelManager.default_kernel_name = os.environ['DEFAULT_KERNEL']
 
-NOTEBOOK_PATH = os.path.join('~', 'work')
-REQUIREMENTS_PATH = os.path.join('~', 'work')
+NOTEBOOK_PATH = os.path.expanduser(os.path.join('~', 'work'))
+REQUIREMENTS_PATH = os.path.expanduser(os.path.join('~', 'work'))
 
 if log_utils.log_file_has_logs(log_utils.USER_VISIBLE_LOGS):
     # redirect to log file
@@ -32,14 +32,14 @@ if log_utils.log_file_has_logs(log_utils.USER_VISIBLE_LOGS):
     platform_persistence.logger.info('user visible error log file has an entry')
 
 else:
-    NOTEBOOK_PATH = os.path.join(NOTEBOOK_PATH, 'notebook.ipynb')
-    c.NotebookApp.default_url = '/notebooks/notebook.ipynb'
-
     nb_file_path = os.environ.get('NOTEBOOK_FILE_PATH')
     if nb_file_path:
         nb_file_path = nb_file_path.strip('/')
-        NOTEBOOK_PATH = os.path.join('~', 'work', os.environ.get('GIT_REPO_FOLDER'), nb_file_path)
-        c.NotebookApp.default_url = '/notebooks/{}/{}'.format(os.environ.get('GIT_REPO_FOLDER'), nb_file_path)
+        NOTEBOOK_PATH = os.path.join(NOTEBOOK_PATH, nb_file_path)
+        c.NotebookApp.default_url = '/notebooks/{}'.format(nb_file_path)
+    else:
+        NOTEBOOK_PATH = os.path.join(NOTEBOOK_PATH, 'notebook.ipynb')
+        c.NotebookApp.default_url = '/notebooks/notebook.ipynb'
 
     try:
         # pull .ipynb file from s3 and save preview back if necessary

--- a/civis_jupyter_notebooks/assets/jupyter_notebook_config.py
+++ b/civis_jupyter_notebooks/assets/jupyter_notebook_config.py
@@ -28,7 +28,7 @@ REQUIREMENTS_PATH = os.path.expanduser(os.path.join('~', 'work'))
 
 if log_utils.log_file_has_logs(log_utils.USER_VISIBLE_LOGS):
     # redirect to log file
-    c.NotebookApp.default_url = '/edit/logs/errors.log'
+    c.NotebookApp.default_url = '/edit/civis-notebook-logs.log'
     platform_persistence.logger.info('user visible error log file has an entry')
 
 else:

--- a/civis_jupyter_notebooks/assets/jupyter_notebook_config.py
+++ b/civis_jupyter_notebooks/assets/jupyter_notebook_config.py
@@ -23,13 +23,13 @@ c.MultiKernelManager.default_kernel_name = os.environ['DEFAULT_KERNEL']
 c.NotebookApp.allow_root = True
 c.FileContentsManager.post_save_hook = platform_persistence.post_save
 
+# check to see if it is git_enabled and if the error log is empty
+
 # Set up NOTEBOOK_PATH
-NOTEBOOK_PATH = os.path.expanduser(os.path.join('~', 'work'))
+NOTEBOOK_PATH = os.path.expanduser(os.path.join('~', 'work', 'notebook.ipynb'))
 nb_file_path = os.environ.get('NOTEBOOK_FILE_PATH')
 if nb_file_path:
-    NOTEBOOK_PATH = os.path.join(NOTEBOOK_PATH, 'repo', nb_file_path.strip('/'))
-else:
-    NOTEBOOK_PATH = os.path.join(NOTEBOOK_PATH, 'notebook.ipynb')
+    NOTEBOOK_PATH = os.path.join(os.environ.get('GIT_REPO_MOUNT_PATH'), nb_file_path.strip('/'))
 
 # pull .ipynb file from s3 and save preview back if necessary
 # pull requirements.txt file from s3

--- a/civis_jupyter_notebooks/assets/jupyter_notebook_config.py
+++ b/civis_jupyter_notebooks/assets/jupyter_notebook_config.py
@@ -10,7 +10,6 @@ import signal
 import pip
 from civis_jupyter_notebooks import platform_persistence
 from civis_jupyter_notebooks.platform_persistence import NotebookManagementError
-from civis_jupyter_notebooks.git_utils import CivisGit, GitError
 
 # Jupyter Configuration
 c = get_config() # noqa
@@ -23,15 +22,6 @@ c.NotebookApp.tornado_settings = {'headers': {'Content-Security-Policy': "frame-
 c.MultiKernelManager.default_kernel_name = os.environ['DEFAULT_KERNEL']
 c.NotebookApp.allow_root = True
 c.FileContentsManager.post_save_hook = platform_persistence.post_save
-
-if os.environ.get('GIT_REPO_URL'):
-    try:
-        platform_persistence.logger.info('cloning git repository')
-        CivisGit().clone_repository()
-        platform_persistence.logger.info('git repository cloned')
-    except GitError as e:
-        platform_persistence.logger.error(str(e))
-        # TODO: Have some sort of check to stop the rest of the code from executing
 
 # Set up NOTEBOOK_PATH
 NOTEBOOK_PATH = os.path.expanduser(os.path.join('~', 'work'))

--- a/civis_jupyter_notebooks/assets/jupyter_notebook_config.py
+++ b/civis_jupyter_notebooks/assets/jupyter_notebook_config.py
@@ -19,37 +19,44 @@ c.NotebookApp.port = 8888
 c.NotebookApp.open_browser = False
 c.NotebookApp.token = ''
 c.NotebookApp.tornado_settings = {'headers': {'Content-Security-Policy': "frame-ancestors *"}}
-c.MultiKernelManager.default_kernel_name = os.environ['DEFAULT_KERNEL']
 c.NotebookApp.allow_root = True
-c.NotebookApp.default_url = '/notebooks/notebook.ipynb'
 c.FileContentsManager.post_save_hook = platform_persistence.post_save
+c.MultiKernelManager.default_kernel_name = os.environ['DEFAULT_KERNEL']
 
-if log_utils.log_file_has_logs(log_utils.USER_LOGS_FILE):
+NOTEBOOK_PATH = os.path.join('~', 'work')
+REQUIREMENTS_PATH = os.path.join('~', 'work')
+
+if log_utils.log_file_has_logs(log_utils.USER_VISIBLE_LOGS):
     # redirect to log file
     c.NotebookApp.default_url = '/edit/logs/errors.log'
     platform_persistence.logger.info('user visible error log file has an entry')
+
 else:
-    NOTEBOOK_PATH = os.path.expanduser(os.path.join('~', 'work', 'notebook.ipynb'))
+    NOTEBOOK_PATH = os.path.join(NOTEBOOK_PATH, 'notebook.ipynb')
+    c.NotebookApp.default_url = '/notebooks/notebook.ipynb'
+
     nb_file_path = os.environ.get('NOTEBOOK_FILE_PATH')
     if nb_file_path:
-        NOTEBOOK_PATH = os.path.join(os.environ.get('GIT_REPO_MOUNT_PATH'), nb_file_path.strip('/'))
-        c.NotebookApp.default_url = os.path.join('/notebooks', 'repo', nb_file_path.strip('/'))
+        nb_file_path = nb_file_path.strip('/')
+        NOTEBOOK_PATH = os.path.join('~', 'work', os.environ.get('GIT_REPO_FOLDER'), nb_file_path)
+        c.NotebookApp.default_url = '/notebooks/{}/{}'.format(os.environ.get('GIT_REPO_FOLDER'), nb_file_path)
 
-    # pull .ipynb file from s3 and save preview back if necessary
-    # pull requirements.txt file from s3
     try:
+        # pull .ipynb file from s3 and save preview back if necessary
+        # pull requirements.txt file from s3
         if not os.path.isfile(NOTEBOOK_PATH):
             platform_persistence.initialize_notebook_from_platform(NOTEBOOK_PATH)
 
         _, preview_url = platform_persistence.get_update_urls()
         platform_persistence.generate_and_save_preview(preview_url, NOTEBOOK_PATH)
+
     except NotebookManagementError as e:
         platform_persistence.logger.error(str(e))
         platform_persistence.logger.warn('Killing the notebook process b/c of a startup issue')
         os.kill(os.getpid(), signal.SIGTERM)
 
     # Install requirements.txt
-    REQUIREMENTS_PATH = os.path.expanduser(os.path.join('~', 'work', 'requirements.txt'))
+    REQUIREMENTS_PATH = os.path.join(REQUIREMENTS_PATH, 'requirements.txt')
     if os.path.isfile(REQUIREMENTS_PATH):
         platform_persistence.logger.info('installing requirements.txt packages')
         pip.main(['install', '-r', REQUIREMENTS_PATH])

--- a/civis_jupyter_notebooks/assets/jupyter_notebook_config.py
+++ b/civis_jupyter_notebooks/assets/jupyter_notebook_config.py
@@ -21,34 +21,36 @@ c.NotebookApp.token = ''
 c.NotebookApp.tornado_settings = {'headers': {'Content-Security-Policy': "frame-ancestors *"}}
 c.MultiKernelManager.default_kernel_name = os.environ['DEFAULT_KERNEL']
 c.NotebookApp.allow_root = True
+c.NotebookApp.default_url = '/notebooks/notebook.ipynb'
 c.FileContentsManager.post_save_hook = platform_persistence.post_save
 
-# if error log has entries ignore extra set up
 if log_utils.log_file_has_logs(log_utils.USER_LOGS_FILE):
     # redirect to log file
-    return # NOQA
+    c.NotebookApp.default_url = '/edit/logs/errors.log'
+    platform_persistence.logger.info('user visible error log file has an entry')
+else:
+    NOTEBOOK_PATH = os.path.expanduser(os.path.join('~', 'work', 'notebook.ipynb'))
+    nb_file_path = os.environ.get('NOTEBOOK_FILE_PATH')
+    if nb_file_path:
+        NOTEBOOK_PATH = os.path.join(os.environ.get('GIT_REPO_MOUNT_PATH'), nb_file_path.strip('/'))
+        c.NotebookApp.default_url = os.path.join('/notebooks', 'repo', nb_file_path.strip('/'))
 
-NOTEBOOK_PATH = os.path.expanduser(os.path.join('~', 'work', 'notebook.ipynb'))
-nb_file_path = os.environ.get('NOTEBOOK_FILE_PATH')
-if nb_file_path:
-    NOTEBOOK_PATH = os.path.join(os.environ.get('GIT_REPO_MOUNT_PATH'), nb_file_path.strip('/'))
+    # pull .ipynb file from s3 and save preview back if necessary
+    # pull requirements.txt file from s3
+    try:
+        if not os.path.isfile(NOTEBOOK_PATH):
+            platform_persistence.initialize_notebook_from_platform(NOTEBOOK_PATH)
 
-# pull .ipynb file from s3 and save preview back if necessary
-# pull requirements.txt file from s3
-try:
-    if not os.path.isfile(NOTEBOOK_PATH):
-        platform_persistence.initialize_notebook_from_platform(NOTEBOOK_PATH)
+        _, preview_url = platform_persistence.get_update_urls()
+        platform_persistence.generate_and_save_preview(preview_url, NOTEBOOK_PATH)
+    except NotebookManagementError as e:
+        platform_persistence.logger.error(str(e))
+        platform_persistence.logger.warn('Killing the notebook process b/c of a startup issue')
+        os.kill(os.getpid(), signal.SIGTERM)
 
-    _, preview_url = platform_persistence.get_update_urls()
-    platform_persistence.generate_and_save_preview(preview_url, NOTEBOOK_PATH)
-except NotebookManagementError as e:
-    platform_persistence.logger.error(str(e))
-    platform_persistence.logger.warn('Killing the notebook process b/c of a startup issue')
-    os.kill(os.getpid(), signal.SIGTERM)
-
-# Install requirements.txt
-REQUIREMENTS_PATH = os.path.expanduser(os.path.join('~', 'work', 'requirements.txt'))
-if os.path.isfile(REQUIREMENTS_PATH):
-    platform_persistence.logger.info('installing requirements.txt packages')
-    pip.main(['install', '-r', REQUIREMENTS_PATH])
-    platform_persistence.logger.info('requirements.txt installed')
+    # Install requirements.txt
+    REQUIREMENTS_PATH = os.path.expanduser(os.path.join('~', 'work', 'requirements.txt'))
+    if os.path.isfile(REQUIREMENTS_PATH):
+        platform_persistence.logger.info('installing requirements.txt packages')
+        pip.main(['install', '-r', REQUIREMENTS_PATH])
+        platform_persistence.logger.info('requirements.txt installed')

--- a/civis_jupyter_notebooks/assets/jupyter_notebook_config.py
+++ b/civis_jupyter_notebooks/assets/jupyter_notebook_config.py
@@ -11,16 +11,8 @@ import pip
 from civis_jupyter_notebooks import platform_persistence
 from civis_jupyter_notebooks.platform_persistence import NotebookManagementError
 
-git_enabled = os.environ.get('GIT_FILE') is not None
-
-if git_enabled:
-    NOTEBOOK_PATH = os.path.join('~', 'work', os.environ.get("GIT_FILE"))
-else:
-    NOTEBOOK_PATH = os.path.join('~', 'work', 'notebook.ipynb')
-NOTEBOOK_PATH = os.path.expanduser(NOTEBOOK_PATH)
-
+# Jupyter Configuration
 c = get_config() # noqa
-
 c.NotebookApp.ip = '*'
 c.NotebookApp.allow_origin = '*'
 c.NotebookApp.port = 8888
@@ -29,11 +21,20 @@ c.NotebookApp.token = ''
 c.NotebookApp.tornado_settings = {'headers': {'Content-Security-Policy': "frame-ancestors *"}}
 c.MultiKernelManager.default_kernel_name = os.environ['DEFAULT_KERNEL']
 c.NotebookApp.allow_root = True
+c.FileContentsManager.post_save_hook = platform_persistence.post_save
+
+git_enabled = os.environ.get('GIT_FILE') is not None
+
+# File paths for notebook file and requirements.txt
+REQUIREMENTS_PATH = os.path.expanduser(os.path.join('~', 'work', 'requirements.txt'))
+NOTEBOOK_PATH = os.path.join('~', 'work', 'notebook.ipynb')
+NOTEBOOK_PATH = os.path.expanduser(NOTEBOOK_PATH)
 
 # Download notebook and initialize post-save hook
 try:
     if not git_enabled or not os.path.isfile(NOTEBOOK_PATH):
         platform_persistence.initialize_notebook_from_platform(NOTEBOOK_PATH)
+
     # force a save of the preview so that we have one in case
     # the user never generates one
     _, preview_url = platform_persistence.get_update_urls()
@@ -43,11 +44,8 @@ except NotebookManagementError as e:
     platform_persistence.logger.warn('Killing the notebook process b/c of a startup issue')
     os.kill(os.getpid(), signal.SIGTERM)
 
-post_save = platform_persistence.post_save(git_enabled=git_enabled)
-c.FileContentsManager.post_save_hook = post_save
-
-REQUIREMENTS_PATH = os.path.expanduser(os.path.join('~', 'work', 'requirements.txt'))
-
+# Clone git repository
+# Install requirements.txt
 if os.path.isfile(REQUIREMENTS_PATH):
     platform_persistence.logger.info('installing requirements.txt packages')
     pip.main(['install', '-r', REQUIREMENTS_PATH])

--- a/civis_jupyter_notebooks/assets/jupyter_notebook_config.py
+++ b/civis_jupyter_notebooks/assets/jupyter_notebook_config.py
@@ -23,32 +23,24 @@ c.NotebookApp.allow_root = True
 c.FileContentsManager.post_save_hook = platform_persistence.post_save
 c.MultiKernelManager.default_kernel_name = os.environ['DEFAULT_KERNEL']
 
-NOTEBOOK_PATH = os.path.expanduser(os.path.join('~', 'work'))
-REQUIREMENTS_PATH = os.path.expanduser(os.path.join('~', 'work'))
+ROOT_DIR = os.path.expanduser(os.path.join('~', 'work'))
 
 if log_utils.log_file_has_logs(log_utils.USER_VISIBLE_LOGS):
     # redirect to log file
     c.NotebookApp.default_url = '/edit/civis-notebook-logs.log'
-    platform_persistence.logger.info('user visible error log file has an entry')
-
 else:
-    nb_file_path = os.environ.get('NOTEBOOK_FILE_PATH')
-    if nb_file_path:
-        nb_file_path = nb_file_path.strip('/')
-        NOTEBOOK_PATH = os.path.join(NOTEBOOK_PATH, nb_file_path)
-        c.NotebookApp.default_url = '/notebooks/{}'.format(nb_file_path)
-    else:
-        NOTEBOOK_PATH = os.path.join(NOTEBOOK_PATH, 'notebook.ipynb')
-        c.NotebookApp.default_url = '/notebooks/notebook.ipynb'
+    nb_file_path = os.environ.get('NOTEBOOK_FILE_PATH', 'notebook.ipynb').strip('/')
+    notebook_full_path = os.path.join(ROOT_DIR, nb_file_path)
+    c.NotebookApp.default_url = '/notebooks/{}'.format(nb_file_path)
 
     try:
         # pull .ipynb file from s3 and save preview back if necessary
         # pull requirements.txt file from s3
-        if not os.path.isfile(NOTEBOOK_PATH):
-            platform_persistence.initialize_notebook_from_platform(NOTEBOOK_PATH)
+        if not os.path.isfile(notebook_full_path):
+            platform_persistence.initialize_notebook_from_platform(notebook_full_path)
 
         _, preview_url = platform_persistence.get_update_urls()
-        platform_persistence.generate_and_save_preview(preview_url, NOTEBOOK_PATH)
+        platform_persistence.generate_and_save_preview(preview_url, notebook_full_path)
 
     except NotebookManagementError as e:
         platform_persistence.logger.error(str(e))
@@ -56,7 +48,7 @@ else:
         os.kill(os.getpid(), signal.SIGTERM)
 
     # Install requirements.txt
-    REQUIREMENTS_PATH = os.path.join(REQUIREMENTS_PATH, 'requirements.txt')
+    REQUIREMENTS_PATH = os.path.join(ROOT_DIR, 'requirements.txt')
     if os.path.isfile(REQUIREMENTS_PATH):
         platform_persistence.logger.info('installing requirements.txt packages')
         pip.main(['install', '-r', REQUIREMENTS_PATH])

--- a/civis_jupyter_notebooks/assets/jupyter_notebook_config.py
+++ b/civis_jupyter_notebooks/assets/jupyter_notebook_config.py
@@ -26,15 +26,18 @@ c.FileContentsManager.post_save_hook = platform_persistence.post_save
 
 if os.environ.get('GIT_REPO_URL'):
     try:
+        platform_persistence.logger.info('cloning git repository')
         CivisGit().clone_repository()
+        platform_persistence.logger.info('git repository cloned')
     except GitError as e:
         platform_persistence.logger.error(str(e))
         # TODO: Have some sort of check to stop the rest of the code from executing
 
 # Set up NOTEBOOK_PATH
 NOTEBOOK_PATH = os.path.expanduser(os.path.join('~', 'work'))
-if os.environ.get('NOTEBOOK_FILE_PATH'):
-    NOTEBOOK_PATH = os.path.join(NOTEBOOK_PATH, os.environ.get('NOTEBOOK_FILE_PATH'))
+nb_file_path = os.environ.get('NOTEBOOK_FILE_PATH')
+if nb_file_path:
+    NOTEBOOK_PATH = os.path.join(NOTEBOOK_PATH, nb_file_path.strip('/'))
 else:
     NOTEBOOK_PATH = os.path.join(NOTEBOOK_PATH, 'notebook.ipynb')
 

--- a/civis_jupyter_notebooks/assets/jupyter_notebook_config.py
+++ b/civis_jupyter_notebooks/assets/jupyter_notebook_config.py
@@ -8,7 +8,7 @@ them not being reimported.
 import os
 import signal
 import pip
-from civis_jupyter_notebooks import platform_persistence
+from civis_jupyter_notebooks import platform_persistence, log_utils
 from civis_jupyter_notebooks.platform_persistence import NotebookManagementError
 
 # Jupyter Configuration
@@ -23,9 +23,11 @@ c.MultiKernelManager.default_kernel_name = os.environ['DEFAULT_KERNEL']
 c.NotebookApp.allow_root = True
 c.FileContentsManager.post_save_hook = platform_persistence.post_save
 
-# check to see if it is git_enabled and if the error log is empty
+# if error log has entries ignore extra set up
+if log_utils.log_file_has_logs(log_utils.USER_LOGS_FILE):
+    # redirect to log file
+    return # NOQA
 
-# Set up NOTEBOOK_PATH
 NOTEBOOK_PATH = os.path.expanduser(os.path.join('~', 'work', 'notebook.ipynb'))
 nb_file_path = os.environ.get('NOTEBOOK_FILE_PATH')
 if nb_file_path:

--- a/civis_jupyter_notebooks/git_utils.py
+++ b/civis_jupyter_notebooks/git_utils.py
@@ -1,0 +1,23 @@
+import os
+from git import Repo
+from git.exc import GitCommandError
+
+
+class CivisGit():
+    def __init__(self):
+        self.repo_url = os.environ.get('GIT_REPO_URL')
+        self.git_repo_mount_path = os.environ.get('GIT_REPO_MOUNT_PATH')
+        self.git_repo_ref = os.environ.get('GIT_REPO_REF')
+
+    def clone_repository(self):
+        try:
+            repo = Repo.clone_from(self.repo_url, self.git_repo_mount_path)
+            repo.git.checkout(self.git_repo_ref)
+        except GitCommandError as e:
+            raise GitError(e)
+
+
+class GitError(Exception):
+    '''
+    General error raised whenever a Git related error comes up
+    '''

--- a/civis_jupyter_notebooks/git_utils.py
+++ b/civis_jupyter_notebooks/git_utils.py
@@ -4,10 +4,10 @@ from git.exc import GitCommandError
 
 
 class CivisGit():
-    def __init__(self):
-        self.repo_url = os.environ.get('GIT_REPO_URL')
-        self.git_repo_mount_path = os.path.expanduser(os.path.join('~', 'work'))
-        self.git_repo_ref = os.environ.get('GIT_REPO_REF')
+    def __init__(self, repo_url=None, repo_mount_path=None, git_repo_ref=None):
+        self.repo_url = os.environ.get('GIT_REPO_URL', repo_url)
+        self.git_repo_mount_path = repo_mount_path if repo_mount_path else os.path.expanduser(os.path.join('~', 'work'))
+        self.git_repo_ref = os.environ.get('GIT_REPO_REF', git_repo_ref)
 
     def clone_repository(self):
         try:

--- a/civis_jupyter_notebooks/git_utils.py
+++ b/civis_jupyter_notebooks/git_utils.py
@@ -14,10 +14,10 @@ class CivisGit():
             repo = Repo.clone_from(self.repo_url, self.git_repo_mount_path)
             repo.git.checkout(self.git_repo_ref)
         except GitCommandError as e:
-            raise GitError(e)
+            raise CivisGitError(e)
 
 
-class GitError(Exception):
-    '''
+class CivisGitError(Exception):
+    """
     General error raised whenever a Git related error comes up
-    '''
+    """

--- a/civis_jupyter_notebooks/git_utils.py
+++ b/civis_jupyter_notebooks/git_utils.py
@@ -6,7 +6,7 @@ from git.exc import GitCommandError
 class CivisGit():
     def __init__(self):
         self.repo_url = os.environ.get('GIT_REPO_URL')
-        self.git_repo_mount_path = os.path.join('~', 'work', os.environ.get('GIT_REPO_FOLDER'))
+        self.git_repo_mount_path = os.path.expanduser(os.path.join('~', 'work'))
         self.git_repo_ref = os.environ.get('GIT_REPO_REF')
 
     def clone_repository(self):

--- a/civis_jupyter_notebooks/git_utils.py
+++ b/civis_jupyter_notebooks/git_utils.py
@@ -6,7 +6,7 @@ from git.exc import GitCommandError
 class CivisGit():
     def __init__(self):
         self.repo_url = os.environ.get('GIT_REPO_URL')
-        self.git_repo_mount_path = os.environ.get('GIT_REPO_MOUNT_PATH')
+        self.git_repo_mount_path = os.path.join('~', 'work', os.environ.get('GIT_REPO_FOLDER'))
         self.git_repo_ref = os.environ.get('GIT_REPO_REF')
 
     def clone_repository(self):

--- a/civis_jupyter_notebooks/log_utils.py
+++ b/civis_jupyter_notebooks/log_utils.py
@@ -2,7 +2,7 @@ import logging
 import os
 import sys
 
-USER_VISIBLE_LOGS = os.path.join('~', 'work', 'logs', 'errors.log')
+USER_VISIBLE_LOGS = os.path.expanduser(os.path.join('~', 'work', 'logs', 'civis.errors.log'))
 
 
 def setup_stream_logging():

--- a/civis_jupyter_notebooks/log_utils.py
+++ b/civis_jupyter_notebooks/log_utils.py
@@ -2,7 +2,7 @@ import logging
 import os
 import sys
 
-USER_VISIBLE_LOGS = os.path.expanduser(os.path.join('~', 'work', 'logs', 'civis.errors.log'))
+USER_VISIBLE_LOGS = os.path.expanduser(os.path.join('~', 'work', 'civis-notebook-logs.log'))
 
 
 def setup_stream_logging():

--- a/civis_jupyter_notebooks/log_utils.py
+++ b/civis_jupyter_notebooks/log_utils.py
@@ -44,3 +44,7 @@ def setup_file_logging():
     handler.setFormatter(formatter)
     logger.addHandler(handler)
     return logger
+
+
+def log_file_has_logs(file_path):
+    return os.path.isfile(file_path) and os.path.getsize(file_path) > 0

--- a/civis_jupyter_notebooks/log_utils.py
+++ b/civis_jupyter_notebooks/log_utils.py
@@ -1,0 +1,46 @@
+import logging
+import os
+import sys
+
+USER_LOGS_FILE = '/root/work/logs/errors.log'
+
+
+def setup_stream_logging():
+    """ Set up log format """
+    logger = logging.getLogger('CIVIS_PLATFORM_BACKEND')
+    logger.setLevel(logging.INFO)
+    # needed to remove duplicate log records..don't know why...
+    logger.propagate = False
+    # make sure to grab orig stderr since things seem to get redirected a bit
+    # by the notebook and/or ipython...
+    ch = logging.StreamHandler(stream=sys.__stderr__)
+    formatter = logging.Formatter(
+        fmt='[%(levelname).1s %(asctime)s %(name)s] %(message)s',
+        datefmt="%H:%M:%S")
+    ch.setLevel(logging.INFO)
+    ch.setFormatter(formatter)
+    logger.addHandler(ch)
+    return logger
+
+
+def setup_file_logging():
+    directory = os.path.dirname(USER_LOGS_FILE)
+    if not os.path.exists(directory):
+        os.makedirs(directory)
+
+    try:
+        open(USER_LOGS_FILE, 'x')
+    except FileExistsError:
+        pass
+
+    logger = logging.getLogger('USER_ERROR_LOGS')
+    logger.setLevel(logging.ERROR)
+    logger.propagate = False
+    handler = logging.FileHandler(USER_LOGS_FILE)
+    formatter = logging.Formatter(
+        fmt='[%(levelname).1s %(asctime)s %(name)s] %(message)s',
+        datefmt="%H:%M:%S")
+    handler.setLevel(logging.ERROR)
+    handler.setFormatter(formatter)
+    logger.addHandler(handler)
+    return logger

--- a/civis_jupyter_notebooks/log_utils.py
+++ b/civis_jupyter_notebooks/log_utils.py
@@ -2,7 +2,7 @@ import logging
 import os
 import sys
 
-USER_LOGS_FILE = os.environ.get('USER_LOG_PATH')
+USER_VISIBLE_LOGS = os.path.join('~', 'work', 'logs', 'errors.log')
 
 
 def setup_stream_logging():
@@ -24,19 +24,17 @@ def setup_stream_logging():
 
 
 def setup_file_logging():
-    directory = os.path.dirname(USER_LOGS_FILE)
+    directory = os.path.dirname(USER_VISIBLE_LOGS)
     if not os.path.exists(directory):
         os.makedirs(directory)
 
-    try:
-        open(USER_LOGS_FILE, 'x')
-    except FileExistsError:
-        pass
+    # python2 and 3 compatible way of opening a file
+    open(USER_VISIBLE_LOGS, 'a').close()
 
-    logger = logging.getLogger('USER_ERROR_LOGS')
+    logger = logging.getLogger('USER_VISIBLE_LOGS')
     logger.setLevel(logging.ERROR)
     logger.propagate = False
-    handler = logging.FileHandler(USER_LOGS_FILE)
+    handler = logging.FileHandler(USER_VISIBLE_LOGS)
     formatter = logging.Formatter(
         fmt='[%(levelname).1s %(asctime)s %(name)s] %(message)s',
         datefmt="%H:%M:%S")

--- a/civis_jupyter_notebooks/log_utils.py
+++ b/civis_jupyter_notebooks/log_utils.py
@@ -2,7 +2,7 @@ import logging
 import os
 import sys
 
-USER_LOGS_FILE = '/root/work/logs/errors.log'
+USER_LOGS_FILE = os.environ.get('USER_LOG_PATH')
 
 
 def setup_stream_logging():

--- a/civis_jupyter_notebooks/platform_persistence.py
+++ b/civis_jupyter_notebooks/platform_persistence.py
@@ -24,6 +24,10 @@ def initialize_notebook_from_platform(notebook_path):
     if r.status_code != 200:
         raise NotebookManagementError('Failed to pull down notebook file from S3')
 
+    directory = os.path.dirname(notebook_path)
+    if not os.path.exists(directory):
+        os.makedirs(directory)
+
     logger.info('Pulling contents of notebook file')
     with open(notebook_path, 'wb') as nb_file:
         nb_file.write(r.content)

--- a/civis_jupyter_notebooks/platform_persistence.py
+++ b/civis_jupyter_notebooks/platform_persistence.py
@@ -47,20 +47,16 @@ def __pull_and_load_requirements(url):
     logger.info('Requirements file ready')
 
 
-def post_save(git_enabled=False):
+def post_save(model, os_path, contents_manager):
+    """ Called from Jupyter post-save hook. Manages save of NB """
 
-    def post_save_custom(model, os_path, contents_manager):
-        """ Called from Jupyter post-save hook. Manages save of NB """
-
-        if model['type'] != 'notebook':
-            return
-        logger.info('Getting URLs to update notebook')
-        update_url, update_preview_url = get_update_urls()
-        if not git_enabled:
-            save_notebook(update_url, os_path)
-        generate_and_save_preview(update_preview_url, os_path)
-        logger.info('Notebook save complete')
-    return post_save_custom
+    if model['type'] != 'notebook':
+        return
+    logger.info('Getting URLs to update notebook')
+    update_url, update_preview_url = get_update_urls()
+    save_notebook(update_url, os_path)
+    generate_and_save_preview(update_preview_url, os_path)
+    logger.info('Notebook save complete')
 
 
 def get_update_urls():

--- a/civis_jupyter_notebooks/platform_persistence.py
+++ b/civis_jupyter_notebooks/platform_persistence.py
@@ -12,6 +12,7 @@ import sys
 import requests
 from subprocess import check_call
 from subprocess import CalledProcessError
+from civis_jupyter_notebooks import log_utils
 
 
 def initialize_notebook_from_platform(notebook_path):
@@ -105,24 +106,6 @@ def get_client():
     return civis.APIClient(resources='all')
 
 
-def setup_logging():
-    """ Set up log format """
-    logger = logging.getLogger('CIVIS_PLATFORM_BACKEND')
-    logger.setLevel(logging.INFO)
-    # needed to remove duplicate log records..don't know why...
-    logger.propagate = False
-    # make sure to grab orig stderr since things seem to get redirected a bit
-    # by the notebook and/or ipython...
-    ch = logging.StreamHandler(stream=sys.__stderr__)
-    formatter = logging.Formatter(
-        fmt='[%(levelname).1s %(asctime)s %(name)s] %(message)s',
-        datefmt="%H:%M:%S")
-    ch.setLevel(logging.INFO)
-    ch.setFormatter(formatter)
-    logger.addHandler(ch)
-    return logger
-
-
 class NotebookManagementError(Exception):
     '''
     raised whenever we hit an error trying to move
@@ -130,4 +113,4 @@ class NotebookManagementError(Exception):
     '''
 
 
-logger = setup_logging()
+logger = log_utils.setup_stream_logging()

--- a/civis_jupyter_notebooks/platform_persistence.py
+++ b/civis_jupyter_notebooks/platform_persistence.py
@@ -6,9 +6,7 @@
   3. Custom Error class for when a Notebook does not correctly initialize
 """
 import civis
-import logging
 import os
-import sys
 import requests
 from subprocess import check_call
 from subprocess import CalledProcessError

--- a/civis_jupyter_notebooks/tests/test_git_utils.py
+++ b/civis_jupyter_notebooks/tests/test_git_utils.py
@@ -7,7 +7,7 @@ import platform
 
 from git.exc import GitCommandError
 from git import Repo
-from civis_jupyter_notebooks.git_utils import CivisGit, GitError
+from civis_jupyter_notebooks.git_utils import CivisGit, CivisGitError
 
 if (six.PY2 or pkg_resources.parse_version('.'.join(platform.python_version_tuple()[0:2]))
         == pkg_resources.parse_version('3.4')):
@@ -32,7 +32,7 @@ class GitUtilsTest(unittest.TestCase):
     @patch('civis_jupyter_notebooks.git_utils.Repo.clone_from')
     def test_clone_repository_throws_error(self, repo_clone):
         repo_clone.side_effect = GitCommandError('clone', 'failed')
-        self.assertRaises(GitError, lambda: CivisGit().clone_repository())
+        self.assertRaises(CivisGitError, lambda: CivisGit().clone_repository())
 
     @patch('civis_jupyter_notebooks.git_utils.Repo.clone_from')
     def test_clone_repository_succeeds(self, repo_clone):

--- a/civis_jupyter_notebooks/tests/test_git_utils.py
+++ b/civis_jupyter_notebooks/tests/test_git_utils.py
@@ -18,7 +18,6 @@ else:
     from unittest.mock import MagicMock
 
 REPO_URL = 'http://www.github.com/civisanalytics.foo.git'
-GIT_REPO_FOLDER = 'repo'
 GIT_REPO_REF = 'master'
 
 
@@ -26,7 +25,6 @@ class GitUtilsTest(unittest.TestCase):
 
     def setUp(self):
         os.environ['GIT_REPO_URL'] = REPO_URL
-        os.environ['GIT_REPO_FOLDER'] = GIT_REPO_FOLDER
         os.environ['GIT_REPO_REF'] = GIT_REPO_REF
         logging.disable(logging.INFO)
 
@@ -40,7 +38,7 @@ class GitUtilsTest(unittest.TestCase):
         repo_clone.return_value = MagicMock(spec=Repo)
         CivisGit().clone_repository()
 
-        repo_mount_path = '~/work/repo'
+        repo_mount_path = '/root/work/'
         repo_clone.assert_called_with(REPO_URL, repo_mount_path)
         repo_clone.return_value.git.checkout.assert_called_with(GIT_REPO_REF)
 

--- a/civis_jupyter_notebooks/tests/test_git_utils.py
+++ b/civis_jupyter_notebooks/tests/test_git_utils.py
@@ -1,0 +1,47 @@
+import unittest
+import os
+import logging
+import six
+import pkg_resources
+import platform
+
+from git.exc import GitCommandError
+from git import Repo
+from civis_jupyter_notebooks.git_utils import CivisGit, GitError
+
+if (six.PY2 or pkg_resources.parse_version('.'.join(platform.python_version_tuple()[0:2]))
+        == pkg_resources.parse_version('3.4')):
+    from mock import patch
+    from mock import MagicMock
+else:
+    from unittest.mock import patch
+    from unittest.mock import MagicMock
+
+REPO_URL = 'http://www.github.com/civisanalytics.foo.git'
+GIT_REPO_MOUNT_PATH = '/root/work'
+GIT_REPO_REF = 'master'
+
+
+class GitUtilsTest(unittest.TestCase):
+
+    def setUp(self):
+        os.environ['GIT_REPO_URL'] = REPO_URL
+        os.environ['GIT_REPO_MOUNT_PATH'] = GIT_REPO_MOUNT_PATH
+        os.environ['GIT_REPO_REF'] = GIT_REPO_REF
+        logging.disable(logging.INFO)
+
+    @patch('civis_jupyter_notebooks.git_utils.Repo.clone_from')
+    def test_clone_repository_throws_error(self, repo_clone):
+        repo_clone.side_effect = GitCommandError('clone', 'failed')
+        self.assertRaises(GitError, lambda: CivisGit().clone_repository())
+
+    @patch('civis_jupyter_notebooks.git_utils.Repo.clone_from')
+    def test_clone_repository_succeeds(self, repo_clone):
+        repo_clone.return_value = MagicMock(spec=Repo)
+        CivisGit().clone_repository()
+        repo_clone.assert_called_with(REPO_URL, GIT_REPO_MOUNT_PATH)
+        repo_clone.return_value.git.checkout.assert_called_with(GIT_REPO_REF)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/civis_jupyter_notebooks/tests/test_git_utils.py
+++ b/civis_jupyter_notebooks/tests/test_git_utils.py
@@ -18,7 +18,7 @@ else:
     from unittest.mock import MagicMock
 
 REPO_URL = 'http://www.github.com/civisanalytics.foo.git'
-GIT_REPO_MOUNT_PATH = '/root/work'
+GIT_REPO_MOUNT_PATH = '/root/work/repo'
 GIT_REPO_REF = 'master'
 
 

--- a/civis_jupyter_notebooks/tests/test_git_utils.py
+++ b/civis_jupyter_notebooks/tests/test_git_utils.py
@@ -18,7 +18,7 @@ else:
     from unittest.mock import MagicMock
 
 REPO_URL = 'http://www.github.com/civisanalytics.foo.git'
-GIT_REPO_MOUNT_PATH = '/root/work/repo'
+GIT_REPO_FOLDER = 'repo'
 GIT_REPO_REF = 'master'
 
 
@@ -26,7 +26,7 @@ class GitUtilsTest(unittest.TestCase):
 
     def setUp(self):
         os.environ['GIT_REPO_URL'] = REPO_URL
-        os.environ['GIT_REPO_MOUNT_PATH'] = GIT_REPO_MOUNT_PATH
+        os.environ['GIT_REPO_FOLDER'] = GIT_REPO_FOLDER
         os.environ['GIT_REPO_REF'] = GIT_REPO_REF
         logging.disable(logging.INFO)
 
@@ -39,7 +39,9 @@ class GitUtilsTest(unittest.TestCase):
     def test_clone_repository_succeeds(self, repo_clone):
         repo_clone.return_value = MagicMock(spec=Repo)
         CivisGit().clone_repository()
-        repo_clone.assert_called_with(REPO_URL, GIT_REPO_MOUNT_PATH)
+
+        repo_mount_path = '~/work/repo'
+        repo_clone.assert_called_with(REPO_URL, repo_mount_path)
         repo_clone.return_value.git.checkout.assert_called_with(GIT_REPO_REF)
 
 

--- a/civis_jupyter_notebooks/tests/test_git_utils.py
+++ b/civis_jupyter_notebooks/tests/test_git_utils.py
@@ -18,6 +18,7 @@ else:
     from unittest.mock import MagicMock
 
 REPO_URL = 'http://www.github.com/civisanalytics.foo.git'
+REPO_MOUNT_PATH = '/root/work'
 GIT_REPO_REF = 'master'
 
 
@@ -36,10 +37,9 @@ class GitUtilsTest(unittest.TestCase):
     @patch('civis_jupyter_notebooks.git_utils.Repo.clone_from')
     def test_clone_repository_succeeds(self, repo_clone):
         repo_clone.return_value = MagicMock(spec=Repo)
-        CivisGit().clone_repository()
+        CivisGit(repo_mount_path=REPO_MOUNT_PATH).clone_repository()
 
-        repo_mount_path = '/root/work/'
-        repo_clone.assert_called_with(REPO_URL, repo_mount_path)
+        repo_clone.assert_called_with(REPO_URL, REPO_MOUNT_PATH)
         repo_clone.return_value.git.checkout.assert_called_with(GIT_REPO_REF)
 
 

--- a/civis_jupyter_notebooks/tests/test_platform_persistence.py
+++ b/civis_jupyter_notebooks/tests/test_platform_persistence.py
@@ -86,8 +86,7 @@ class MyTest(unittest.TestCase):
     @patch('civis.APIClient')
     @patch('requests.put')
     def test_post_save_fetches_urls_from_api(self, _rput, client, _ccc, _op):
-        post_save = platform_persistence.post_save(git_enabled=False)
-        post_save({'type': 'notebook'}, '', {})
+        platform_persistence.post_save({'type': 'notebook'}, '', {})
         platform_persistence.get_client().notebooks.list_update_links.assert_called_with(TEST_PLATFORM_OBJECT_ID)
 
     @patch('civis_jupyter_notebooks.platform_persistence.open')
@@ -96,19 +95,8 @@ class MyTest(unittest.TestCase):
     @patch('requests.put')
     @patch('civis_jupyter_notebooks.platform_persistence.save_notebook')
     def test_post_save_performs_two_put_operations(self, save, rput, _client, _ccc, _op):
-        post_save = platform_persistence.post_save(git_enabled=False)
-        post_save({'type': 'notebook'}, '', {})
+        platform_persistence.post_save({'type': 'notebook'}, '', {})
         self.assertTrue(save.called)
-
-    @patch('civis_jupyter_notebooks.platform_persistence.open')
-    @patch('civis_jupyter_notebooks.platform_persistence.check_call')
-    @patch('civis.APIClient')
-    @patch('requests.put')
-    @patch('civis_jupyter_notebooks.platform_persistence.save_notebook')
-    def test_post_save_for_git_does_not_call_save_notebook(self, save, rput, _client, _ccc, _op):
-        post_save = platform_persistence.post_save(git_enabled=True)
-        post_save({'type': 'notebook'}, '', {})
-        self.assertFalse(save.called)
 
     @patch('civis_jupyter_notebooks.platform_persistence.open')
     @patch('civis_jupyter_notebooks.platform_persistence.check_call')
@@ -117,8 +105,7 @@ class MyTest(unittest.TestCase):
     @patch('civis_jupyter_notebooks.platform_persistence.save_notebook')
     @patch('civis_jupyter_notebooks.platform_persistence.get_update_urls')
     def test_post_save_skipped_for_non_notebook_types(self, guu, save, _rput, _client, _ccc, _op):
-        post_save = platform_persistence.post_save(git_enabled=False)
-        post_save({'type': 'blargggg'}, '', {})
+        platform_persistence.post_save({'type': 'blargggg'}, '', {})
         self.assertFalse(guu.called)
         self.assertFalse(save.called)
 
@@ -127,17 +114,7 @@ class MyTest(unittest.TestCase):
     @patch('civis.APIClient')
     @patch('requests.put')
     def test_post_save_generates_preview(self, _rput, _client, check_call, _op):
-        post_save = platform_persistence.post_save(git_enabled=False)
-        post_save({'type': 'notebook'}, 'x/y', {})
-        check_call.assert_called_with(['jupyter', 'nbconvert', '--to', 'html', 'y'], cwd='x')
-
-    @patch('civis_jupyter_notebooks.platform_persistence.open')
-    @patch('civis_jupyter_notebooks.platform_persistence.check_call')
-    @patch('civis.APIClient')
-    @patch('requests.put')
-    def test_post_save_for_git_generates_preview(self, _rput, _client, check_call, _op):
-        post_save = platform_persistence.post_save(git_enabled=True)
-        post_save({'type': 'notebook'}, 'x/y', {})
+        platform_persistence.post_save({'type': 'notebook'}, 'x/y', {})
         check_call.assert_called_with(['jupyter', 'nbconvert', '--to', 'html', 'y'], cwd='x')
 
     @patch('civis_jupyter_notebooks.platform_persistence.open')

--- a/civis_jupyter_notebooks/tests/test_platform_persistence.py
+++ b/civis_jupyter_notebooks/tests/test_platform_persistence.py
@@ -30,19 +30,21 @@ class MyTest(unittest.TestCase):
 
         logging.disable(logging.INFO)
 
+    @patch('os.makedirs')
     @patch('civis_jupyter_notebooks.platform_persistence.open')
     @patch('civis.APIClient')
     @patch('civis_jupyter_notebooks.platform_persistence.requests.get')
-    def test_initialize_notebook_will_get_nb_from_platform(self, rg, _client, _op):
+    def test_initialize_notebook_will_get_nb_from_platform(self, rg, _client, _op, _makedirs):
         rg.return_value = MagicMock(spec=requests.Response, status_code=200, response={})
         platform_persistence.initialize_notebook_from_platform(TEST_NOTEBOOK_PATH)
         platform_persistence.get_client().notebooks.get.assert_called_with(TEST_PLATFORM_OBJECT_ID)
 
+    @patch('os.makedirs')
     @patch('civis_jupyter_notebooks.platform_persistence.open')
     @patch('civis_jupyter_notebooks.platform_persistence.__pull_and_load_requirements')
     @patch('civis.APIClient')
     @patch('civis_jupyter_notebooks.platform_persistence.requests.get')
-    def test_initialize_notebook_will_pull_nb_from_url(self, rg, _client, requirements, _op):
+    def test_initialize_notebook_will_pull_nb_from_url(self, rg, _client, requirements, _op, _makedirs):
         url = 'http://whatever'
         rg.return_value = MagicMock(spec=requests.Response, status_code=200, response={})
         platform_persistence.get_client().notebooks.get.return_value.notebook_url = url
@@ -60,21 +62,33 @@ class MyTest(unittest.TestCase):
                           lambda: platform_persistence.initialize_notebook_from_platform(TEST_NOTEBOOK_PATH))
 
     @patch('civis_jupyter_notebooks.platform_persistence.open')
+    @patch('civis.APIClient')
+    @patch('os.makedirs')
+    @patch('civis_jupyter_notebooks.platform_persistence.requests.get')
+    def test_initialize_notebook_will_create_directories_if_needed(self, rg, makedirs, _client, _op):
+        rg.return_value = MagicMock(spec=requests.Response, status_code=200, response={})
+        platform_persistence.initialize_notebook_from_platform(TEST_NOTEBOOK_PATH)
+        directory = os.path.dirname(TEST_NOTEBOOK_PATH)
+        makedirs.assert_called_with(directory)
+
+    @patch('os.makedirs')
+    @patch('civis_jupyter_notebooks.platform_persistence.open')
     @patch('civis_jupyter_notebooks.platform_persistence.__pull_and_load_requirements')
     @patch('civis.APIClient')
     @patch('civis_jupyter_notebooks.platform_persistence.requests.get')
-    def test_initialize_notebook_will_pull_requirements(self, rg, _client, requirements, _op):
+    def test_initialize_notebook_will_pull_requirements(self, rg, _client, requirements, _op, _makedirs):
         url = 'http://whatever'
         rg.return_value = MagicMock(spec=requests.Response, status_code=200, response={})
         platform_persistence.get_client().notebooks.get.return_value.requirements_url = url
         platform_persistence.initialize_notebook_from_platform(TEST_NOTEBOOK_PATH)
         requirements.assert_called_with(url)
 
+    @patch('os.makedirs')
     @patch('civis_jupyter_notebooks.platform_persistence.open')
     @patch('civis_jupyter_notebooks.platform_persistence.__pull_and_load_requirements')
     @patch('civis.APIClient')
     @patch('civis_jupyter_notebooks.platform_persistence.requests.get')
-    def test_initialize_notebook_will_error_on_requirements_pull(self, rg, _client, _requirements, _op):
+    def test_initialize_notebook_will_error_on_requirements_pull(self, rg, _client, _requirements, _op, _makedirs):
         url = 'http://whatever'
         rg.return_value = MagicMock(spec=requests.Response, status_code=500, response={})
         platform_persistence.get_client().notebooks.get.return_value.requirements_url = url

--- a/civis_jupyter_notebooks/tests/test_platform_persistence.py
+++ b/civis_jupyter_notebooks/tests/test_platform_persistence.py
@@ -22,7 +22,7 @@ TEST_NOTEBOOK_PATH = '/path/to/notebook.ipynb'
 TEST_PLATFORM_OBJECT_ID = '1914'
 
 
-class MyTest(unittest.TestCase):
+class PlatformPersistenceTest(unittest.TestCase):
 
     def setUp(self):
         os.environ['CIVIS_API_KEY'] = 'hi mom'

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ click~=6.7
 notebook~=5.1.0
 six~=1.10.0
 civis-jupyter-extensions~=0.1.2
+GitPython~=2.1

--- a/setup.py
+++ b/setup.py
@@ -25,8 +25,7 @@ setup(
     install_requires=read('requirements.txt').strip().split('\n'),
     scripts=[
         'civis_jupyter_notebooks/assets/civis-jupyter-notebooks-start',
-        'civis_jupyter_notebooks/assets/git-init',
-        'civis_jupyter_notebooks/assets/git-clone'
+        'civis_jupyter_notebooks/assets/git-init'
     ],
     entry_points={
         'console_scripts': [

--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,8 @@ setup(
     install_requires=read('requirements.txt').strip().split('\n'),
     scripts=[
         'civis_jupyter_notebooks/assets/civis-jupyter-notebooks-start',
-        'civis_jupyter_notebooks/assets/git-init'
+        'civis_jupyter_notebooks/assets/git-init',
+        'civis_jupyter_notebooks/assets/git-clone'
     ],
     entry_points={
         'console_scripts': [

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ setup(
     scripts=[
         'civis_jupyter_notebooks/assets/civis-jupyter-notebooks-start',
         'civis_jupyter_notebooks/assets/initialize-git',
-        'civis_jupyter_notebooks/assets/git-clone'
+        'civis_jupyter_notebooks/assets/civis-git-clone'
     ],
     entry_points={
         'console_scripts': [

--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ setup(
     install_requires=read('requirements.txt').strip().split('\n'),
     scripts=[
         'civis_jupyter_notebooks/assets/civis-jupyter-notebooks-start',
-        'civis_jupyter_notebooks/assets/git-init',
+        'civis_jupyter_notebooks/assets/initialize-git',
         'civis_jupyter_notebooks/assets/git-clone'
     ],
     entry_points={


### PR DESCRIPTION
Git clone via GitPython with error handling. Errors get written to a log file and is displayed on startup if there are errors. Otherwise, notebook is displayed on startup.

Couple of things I could do but figured could wait:
- Add unit tests for the `log_utils.py` functions. They're just setting up loggers though ... 
- Make the `GitError` exception more user friendly so that log file has a more understandable message. 

