### PR TITLE
[CIVP-18122] Support Notebooks with Bitbucket

### DIFF
--- a/civis_jupyter_notebooks/assets/initialize-git
+++ b/civis_jupyter_notebooks/assets/initialize-git
@@ -14,7 +14,7 @@ if test $GIT_CREDENTIAL; then
   git config --global credential.helper 'cache --timeout=10000000'
   git credential approve <<EOF
 protocol=https
-host=github.com
+host=$GIT_HOST
 username=$GIT_CREDENTIAL
 password=x-oauth-basic
 EOF


### PR DESCRIPTION
This PR:

- Sets the git host URL to be whatever value is stored in the ENV var `GIT_HOST`. 