### PR TITLE
[CIVP-18029] Update notebooks version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,10 +1,7 @@
 civis~=1.6
 requests~=2.18
 click~=6.7
-notebook~=5.1,!=5.7.*
-# for versions of jupyter before 5.7.5 we need to specify tornado<6
-# as these older versions of jupyter will break with tornado 6
-tornado<6
+notebook>=5.7.5,<6.0.0
 six~=1.10
 civis-jupyter-extensions~=0.1
 GitPython~=2.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,7 @@
 civis~=1.6
 requests~=2.18
 click~=6.7
-notebook~=5.1,!=5.7.*
-tornado==5.1.1
+notebook>=5.7.5,<6.0.0
 six~=1.10
 civis-jupyter-extensions~=0.1
 GitPython~=2.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,7 @@ civis~=1.6
 requests~=2.18
 click~=6.7
 notebook>=5.7.5,<6.0.0
+prompt-toolkit==2.0.9
 six~=1.10
 civis-jupyter-extensions~=0.1
 GitPython~=2.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ civis~=1.6
 requests~=2.18
 click~=6.7
 notebook>=5.7.5,<6.0.0
-tornado~=6.0.1
+tornado==5.1.1
 six~=1.10
 civis-jupyter-extensions~=0.1
 GitPython~=2.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 civis~=1.6
 requests~=2.18
 click~=6.7
-notebook>=5.7.5,<6.0.0
+notebook~=5.1,!=5.7.*
 tornado==5.1.1
 six~=1.10
 civis-jupyter-extensions~=0.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,7 @@ civis~=1.6
 requests~=2.18
 click~=6.7
 notebook>=5.7.5,<6.0.0
+tornado~=6.0.1
 six~=1.10
 civis-jupyter-extensions~=0.1
 GitPython~=2.1


### PR DESCRIPTION
This PR handles:
- Upgrading the notebook package to `notebook>=5.7.5,<6.0.0`
- Setting tornado package to `tornado~=6.0.1` which is compatible with notebook v5.7.5. See issue here: https://github.com/jupyter/notebook/issues/4439