### PR TITLE
[CIVP-18337] Update stream logging to address notebook log colors

### DIFF
--- a/civis_jupyter_notebooks/assets/civis-git-clone
+++ b/civis_jupyter_notebooks/assets/civis-git-clone
@@ -12,6 +12,7 @@ if os.environ.get('GIT_REPO_URL'):
         CivisGit().clone_repository()
         stream_logger.info('clone complete')
     except CivisGitError as e:
+        stream_logger.error('error clonging git repository: {}'.format(str(e)))
         # Initialize logger here so directory is empty for git clone
         file_logger = log_utils.setup_file_logging()
         file_logger.error(str(e))

--- a/civis_jupyter_notebooks/log_utils.py
+++ b/civis_jupyter_notebooks/log_utils.py
@@ -58,6 +58,20 @@ def setup_stream_logging():
 
 
 def setup_file_logging():
+    """
+    Configure the USER_VISIBLE_LOGS for file logging.
+
+    File logging is intended for errors to be shown to the user.
+    E.g. If we fail to install requirements, then we redirect
+    c.NotebookApp.default_url to point to this log file.
+
+    TODO: This was written during the intial development
+    of notebooks and may no longer be necessary. CIVP-18444
+
+    Returns
+    -------
+    The USER_VISIBLE_LOGS logger
+    """
     directory = os.path.dirname(USER_VISIBLE_LOGS)
     if not os.path.exists(directory):
         os.makedirs(directory)
@@ -75,6 +89,7 @@ def setup_file_logging():
     handler.setLevel(logging.ERROR)
     handler.setFormatter(formatter)
     logger.addHandler(handler)
+
     return logger
 
 

--- a/civis_jupyter_notebooks/log_utils.py
+++ b/civis_jupyter_notebooks/log_utils.py
@@ -7,21 +7,53 @@ USER_LOGS_URL = '/edit/civis-notebook-logs.log'
 USER_VISIBLE_LOGS = os.path.expanduser(os.path.join('~', 'work', 'civis-notebook-logs.log'))
 
 
+# Adapted from https://stackoverflow.com/a/1383365
+class SingleLevelFilter(logging.Filter):
+    def __init__(self, passlevel):
+        self.passlevel = passlevel
+
+    def filter(self, record):
+        return (record.levelno == self.passlevel)
+
+
 def setup_stream_logging():
-    """ Set up log format """
+    """
+    Configure the CIVIS_PLATFORM_BACKEND logger for stream logging.
+
+    DEBUG level logs will be ignored,
+    INFO level logs will be sent to stdout,
+    WARNING, ERROR, & CRITICAL level logs will be sent to stderr.
+
+    Returns
+    -------
+    The CIVIS_PLATFORM_BACKEND logger
+    """
     logger = logging.getLogger('CIVIS_PLATFORM_BACKEND')
-    logger.setLevel(logging.INFO)
-    # needed to remove duplicate log records..don't know why...
+
+    # prevents duplicate log records by preventing messages from being passed to ancestor loggers, e.g. the root logger
     logger.propagate = False
-    # make sure to grab orig stderr since things seem to get redirected a bit
-    # by the notebook and/or ipython...
-    ch = logging.StreamHandler(stream=sys.__stderr__)
+
+    # Sets the lowest level which this logger will pay attention to (i.e. ignore debug level logs)
+    logger.setLevel(logging.INFO)
+
     formatter = logging.Formatter(
         fmt='[%(levelname).1s %(asctime)s %(name)s] %(message)s',
         datefmt="%H:%M:%S")
-    ch.setLevel(logging.INFO)
-    ch.setFormatter(formatter)
-    logger.addHandler(ch)
+
+    # Configures a handler for sending warning level and above logs to stderr
+    error_handler = logging.StreamHandler(stream=sys.__stderr__)
+    error_handler.setLevel(logging.WARNING)
+    error_handler.setFormatter(formatter)
+    logger.addHandler(error_handler)
+
+    # Configures a handler for sending info level logs to stdout
+    info_handler = logging.StreamHandler(stream=sys.__stdout__)
+    info_handler.setLevel(logging.INFO)
+    # Filter so that the info handler will handle ONLY info level logs
+    info_handler.addFilter(SingleLevelFilter(logging.INFO))
+    info_handler.setFormatter(formatter)
+    logger.addHandler(info_handler)
+
     return logger
 
 

--- a/civis_jupyter_notebooks/notebook_config.py
+++ b/civis_jupyter_notebooks/notebook_config.py
@@ -24,7 +24,7 @@ def find_and_install_requirements(requirements_path, c):
     except platform_persistence.NotebookManagementError as e:
         # redirect to log file if pip fails
         error_msg = "Unable to install requirements.txt:\n" + str(e)
-        platform_persistence.logger.info(error_msg)
+        platform_persistence.logger.error(error_msg)
         file_logger = log_utils.setup_file_logging()
         file_logger.error(error_msg)
         platform_persistence.logger.info('Setting NotebookApp.default_url to %s' % log_utils.USER_LOGS_URL)


### PR DESCRIPTION
Update stream logging to address notebook log colors.

## Changes
* Reconfigure stream logging logger:
  * `INFO` level logs will be sent to `stdout`
  * `WARNING` and above level logs will be sent to `stderr`
* Log all errors to the stream logger
* Update docs for both loggers

This has been tested by integration with a python3 notebook docker image & test log messages. Info level messages show up in black, warning+ messages show up in red:
![Screen Shot 2019-05-08 at 4 39 32 PM](https://user-images.githubusercontent.com/6098376/57410659-0a737680-71b1-11e9-8f77-838131a87430.png)
