### PR TITLE
[CIVP-18425] Change Python versions in automated tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,12 +3,13 @@ notifications:
 sudo: required
 services:
   - docker
+dist: xenial
 language: python
 python:
   - "2.7"
-  - "3.4"
   - "3.5"
   - "3.6"
+  - "3.7"
 install:
   - pip install --upgrade pip setuptools
   - pip install -r requirements.txt
@@ -18,7 +19,7 @@ script:
   - flake8 civis_jupyter_notebooks
   - pytest -vv civis_jupyter_notebooks
   - |
-    if [ ${TRAVIS_PYTHON_VERSION} = 3.6 ]
+    if [ ${TRAVIS_PYTHON_VERSION} = 3.7 ]
     then
         ./tests/run_docker_tests.sh tests/python3/Dockerfile
     fi


### PR DESCRIPTION
Python 3.4 has reached end-of-life: https://www.python.org/dev/peps/pep-0429/

This PR will end the automated testing against Python 3.4, and add automated testing against Python 3.7.