### PR TITLE
[CIVP-18444] Remove file logger

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## Unreleased
+### Removed
+- File logging. All logs will now be written to stdout/stderr streams. (#47)
+
 ## [1.0.0] - 2019-05-10
 
 ### Removed

--- a/civis_jupyter_notebooks/assets/civis-git-clone
+++ b/civis_jupyter_notebooks/assets/civis-git-clone
@@ -13,6 +13,3 @@ if os.environ.get('GIT_REPO_URL'):
         stream_logger.info('clone complete')
     except CivisGitError as e:
         stream_logger.error('error clonging git repository: {}'.format(str(e)))
-        # Initialize logger here so directory is empty for git clone
-        file_logger = log_utils.setup_file_logging()
-        file_logger.error(str(e))

--- a/civis_jupyter_notebooks/log_utils.py
+++ b/civis_jupyter_notebooks/log_utils.py
@@ -1,5 +1,4 @@
 import logging
-import os
 import sys
 
 

--- a/civis_jupyter_notebooks/log_utils.py
+++ b/civis_jupyter_notebooks/log_utils.py
@@ -2,10 +2,6 @@ import logging
 import os
 import sys
 
-USER_LOGS_URL = '/edit/civis-notebook-logs.log'
-
-USER_VISIBLE_LOGS = os.path.expanduser(os.path.join('~', 'work', 'civis-notebook-logs.log'))
-
 
 # Adapted from https://stackoverflow.com/a/1383365
 class SingleLevelFilter(logging.Filter):
@@ -55,43 +51,3 @@ def setup_stream_logging():
     logger.addHandler(info_handler)
 
     return logger
-
-
-def setup_file_logging():
-    """
-    Configure the USER_VISIBLE_LOGS for file logging.
-
-    File logging is intended for errors to be shown to the user.
-    E.g. If we fail to install requirements, then we redirect
-    c.NotebookApp.default_url to point to this log file.
-
-    TODO: This was written during the intial development
-    of notebooks and may no longer be necessary. CIVP-18444
-
-    Returns
-    -------
-    The USER_VISIBLE_LOGS logger
-    """
-    directory = os.path.dirname(USER_VISIBLE_LOGS)
-    if not os.path.exists(directory):
-        os.makedirs(directory)
-
-    # python2 and 3 compatible way of opening a file
-    open(USER_VISIBLE_LOGS, 'a').close()
-
-    logger = logging.getLogger('USER_VISIBLE_LOGS')
-    logger.setLevel(logging.ERROR)
-    logger.propagate = False
-    handler = logging.FileHandler(USER_VISIBLE_LOGS)
-    formatter = logging.Formatter(
-        fmt='[%(levelname).1s %(asctime)s %(name)s] %(message)s',
-        datefmt="%H:%M:%S")
-    handler.setLevel(logging.ERROR)
-    handler.setFormatter(formatter)
-    logger.addHandler(handler)
-
-    return logger
-
-
-def log_file_has_logs(file_path):
-    return os.path.isfile(file_path) and os.path.getsize(file_path) > 0

--- a/civis_jupyter_notebooks/notebook_config.py
+++ b/civis_jupyter_notebooks/notebook_config.py
@@ -22,13 +22,8 @@ def find_and_install_requirements(requirements_path, c):
     try:
         platform_persistence.find_and_install_requirements(requirements_path)
     except platform_persistence.NotebookManagementError as e:
-        # redirect to log file if pip fails
         error_msg = "Unable to install requirements.txt:\n" + str(e)
         platform_persistence.logger.error(error_msg)
-        file_logger = log_utils.setup_file_logging()
-        file_logger.error(error_msg)
-        platform_persistence.logger.info('Setting NotebookApp.default_url to %s' % log_utils.USER_LOGS_URL)
-        c.NotebookApp.default_url = log_utils.USER_LOGS_URL
 
 
 def config_jupyter(c):
@@ -58,16 +53,12 @@ def stage_new_notebook(notebook_file_path):
 def civis_setup(c):
     config_jupyter(c)
 
-    if log_utils.log_file_has_logs(log_utils.USER_VISIBLE_LOGS):
-        # redirect to log file
-        c.NotebookApp.default_url = log_utils.USER_LOGS_URL
-    else:
-        nb_file_path = os.environ.get('NOTEBOOK_FILE_PATH', 'notebook.ipynb').strip('/')
-        notebook_full_path = os.path.join(ROOT_DIR, nb_file_path)
-        c.NotebookApp.default_url = '/notebooks/{}'.format(nb_file_path)
+    nb_file_path = os.environ.get('NOTEBOOK_FILE_PATH', 'notebook.ipynb').strip('/')
+    notebook_full_path = os.path.join(ROOT_DIR, nb_file_path)
+    c.NotebookApp.default_url = '/notebooks/{}'.format(nb_file_path)
 
-        get_notebook(notebook_full_path)
-        stage_new_notebook(nb_file_path)
+    get_notebook(notebook_full_path)
+    stage_new_notebook(nb_file_path)
 
-        requirements_path = os.path.dirname(notebook_full_path)
-        find_and_install_requirements(requirements_path, c)
+    requirements_path = os.path.dirname(notebook_full_path)
+    find_and_install_requirements(requirements_path, c)

--- a/civis_jupyter_notebooks/notebook_config.py
+++ b/civis_jupyter_notebooks/notebook_config.py
@@ -1,7 +1,7 @@
 import os
 import signal
 
-from civis_jupyter_notebooks import platform_persistence, log_utils
+from civis_jupyter_notebooks import platform_persistence
 from civis_jupyter_notebooks.git_utils import CivisGit
 
 

--- a/civis_jupyter_notebooks/tests/test_notebook_config.py
+++ b/civis_jupyter_notebooks/tests/test_notebook_config.py
@@ -3,16 +3,15 @@ import six
 import os
 import pkg_resources
 import platform
-import logging
 from traitlets.config.loader import Config
 
-from civis_jupyter_notebooks import notebook_config, platform_persistence, log_utils
+from civis_jupyter_notebooks import notebook_config, platform_persistence
 
 if (six.PY2 or pkg_resources.parse_version('.'.join(platform.python_version_tuple()[0:2]))
         == pkg_resources.parse_version('3.4')):
-    from mock import patch, MagicMock, ANY
+    from mock import patch, ANY
 else:
-    from unittest.mock import patch, MagicMock, ANY
+    from unittest.mock import patch, ANY
 
 
 class NotebookConfigTest(unittest.TestCase):

--- a/civis_jupyter_notebooks/tests/test_notebook_config.py
+++ b/civis_jupyter_notebooks/tests/test_notebook_config.py
@@ -48,28 +48,21 @@ class NotebookConfigTest(unittest.TestCase):
 
     @patch('civis_jupyter_notebooks.platform_persistence.find_and_install_requirements')
     @patch('civis_jupyter_notebooks.platform_persistence.logger')
-    @patch('civis_jupyter_notebooks.log_utils.setup_file_logging')
-    def test_find_and_install_requirements_shows_errors(self, log_setup, logger, persistence_find_and_install_requirements):
-        mock_logger = MagicMock(logging.Logger)
+    def test_find_and_install_requirements_logs_errors(self, logger, persistence_find_and_install_requirements):
         persistence_find_and_install_requirements.side_effect = platform_persistence.NotebookManagementError('err')
-        log_setup.return_value = mock_logger
         c = Config({})
         notebook_config.find_and_install_requirements('path', c)
-        mock_logger.error.assert_called_with("Unable to install requirements.txt:\nerr")
-        assert(c.NotebookApp.default_url == log_utils.USER_LOGS_URL)
+        logger.error.assert_called_with("Unable to install requirements.txt:\nerr")
 
     @patch('civis_jupyter_notebooks.notebook_config.stage_new_notebook')
     @patch('civis_jupyter_notebooks.notebook_config.config_jupyter')
     @patch('civis_jupyter_notebooks.notebook_config.find_and_install_requirements')
     @patch('civis_jupyter_notebooks.notebook_config.get_notebook')
-    @patch('civis_jupyter_notebooks.log_utils.log_file_has_logs')
     def test_civis_setup_success(
             self,
-            log_file_has_logs, get_notebook, find_and_install_requirements,
+            get_notebook, find_and_install_requirements,
             config_jupyter, _stage_new_notebook):
         c = Config({})
-        log_file_has_logs.return_value = False
-
         notebook_config.civis_setup(c)
 
         assert(c.NotebookApp.default_url == '/notebooks/notebook.ipynb')
@@ -82,28 +75,19 @@ class NotebookConfigTest(unittest.TestCase):
     @patch('civis_jupyter_notebooks.notebook_config.config_jupyter')
     @patch('civis_jupyter_notebooks.notebook_config.find_and_install_requirements')
     @patch('civis_jupyter_notebooks.notebook_config.get_notebook')
-    @patch('civis_jupyter_notebooks.log_utils.log_file_has_logs')
     def test_civis_setup_uses_environment_setting(
             self,
-            log_file_has_logs, get_notebook, find_and_install_requirements,
+            get_notebook, find_and_install_requirements,
             config_jupyter, environ_get, _stage_new_notebook):
 
         c = Config({})
-        log_file_has_logs.return_value = False
         environ_get.return_value = 'subpath/foo.ipynb'
         notebook_config.civis_setup(c)
+
         assert(c.NotebookApp.default_url == '/notebooks/subpath/foo.ipynb')
         config_jupyter.assert_called_with(ANY)
         get_notebook.assert_called_with(notebook_config.ROOT_DIR + '/subpath/foo.ipynb')
         find_and_install_requirements.assert_called_with(notebook_config.ROOT_DIR + '/subpath', ANY)
-
-    @patch('civis_jupyter_notebooks.log_utils.log_file_has_logs')
-    @patch('civis_jupyter_notebooks.notebook_config.config_jupyter')
-    def test_civis_setup_redirects_to_logs(self, log_file_has_logs, _config_jupyter):
-        c = Config({})
-        log_file_has_logs.return_value = True
-        notebook_config.civis_setup(c)
-        assert(c.NotebookApp.default_url == log_utils.USER_LOGS_URL)
 
     @patch('civis_jupyter_notebooks.notebook_config.CivisGit')
     def test_stage_new_notebook_stages_notebook_file(self, civis_git):


### PR DESCRIPTION
Remove the file logger as it is no longer useful. It was used as a debugging tool when notebooks were first built.

All logging should use the stream logging from now on.